### PR TITLE
Revert "use more performant RapidFuzz instead of unmaintained python-Levenshtein"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ by using either ``.get`` or ``[]``::
    >>> a.get("micael asiak")
    [(0.8461538461538461, u'michael axiak')]
 
-The result will be a list of ``(score, matched_value)`` tuples.
+The result will be a list of ``(score, mached_value)`` tuples.
 The score is between 0 and 1, with 1 being a perfect match.
 
 For roughly 15% performance increase, there is also a Cython-implemented

--- a/fuzzyset/__init__.py
+++ b/fuzzyset/__init__.py
@@ -2,7 +2,7 @@ import re
 import math
 import operator
 import collections
-from rapidfuzz.string_metric import normalized_levenshtein
+import Levenshtein
 
 __version__ = "0.1.1"
 __version_info__ = tuple(__version__.split("."))
@@ -99,7 +99,11 @@ class FuzzySet(object):
 
 
 def _distance(str1, str2):
-    return normalized_levenshtein(str1, str2)/100
+    distance = Levenshtein.distance(str1, str2)
+    if len(str1) > len(str2):
+        return 1 - float(distance) / len(str1)
+    else:
+        return 1 - float(distance) / len(str2)
 
 
 def _gram_counter(value, gram_size=2):

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
     packages=['fuzzyset'],
     long_description=read('README.rst'),
     long_description_content_type="text/x-rst",
-    install_requires=['rapidfuzz'],
+    install_requires=['python-levenshtein'],
     test_require=["texttable", "pytest"],
     classifiers=[
         "Development Status :: 3 - Alpha",


### PR DESCRIPTION
Reverts alpae/fuzzyset#2